### PR TITLE
allow versioned symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,18 @@ Notably if you create a symlink of `foo` to `tea` (or `tea_foo`) we will
 interpret that as `tea -X foo [args…]`, yet another way using `tea` can be
 completely transparent to your everyday workflows.
 
+Even better, you can include semver ranges in your link name, so `ln -s tea node^16`
+will let you run `node^16` via the symlink of the same name. For even, even more
+goodness, we will follow a symlink one deep to see if a base link goes to a versioned
+link. Example:
+
+```sh
+$ ln -s tea node^16
+$ ln -s node node^16
+$ node --version
+v16.19.0
+```
+
 > ### Coming Soon
 >
 > ```yaml

--- a/src/app.X.ts
+++ b/src/app.X.ts
@@ -20,7 +20,7 @@ export default async function X(opts: Args) {
   const pkg = pkgs.find(x => x.project == found!.project) ?? panic()
   const install = await useCellar().resolve(pkg)
   const cmd = opts.args
-  cmd[0] = install.path.join('bin', arg0).string  // force full path to avoid infinite recursion
+  cmd[0] = install.path.join('bin', found!.shebang).string  // force full path to avoid infinite recursion
   try {
     await run({ cmd, env })
   } catch (err) {

--- a/src/hooks/useFlags.ts
+++ b/src/hooks/useFlags.ts
@@ -65,8 +65,13 @@ export function useArgs(args: string[], arg0: string): [Args, Flags & Convenienc
   if (flags) throw new Error("contract-violated");
 
   (() => {
-    const base = new Path(arg0).isSymlink()?.basename()
-    if (base === undefined || base === "tea") return
+    const link = new Path(arg0).isSymlink()
+    if (link === undefined || link.basename() === "tea") return
+    const target = link.readlink().isSymlink()
+    // if node is a symlink to node^16 to tea, then we should use node^16
+    const base = target?.basename().startsWith(link.basename())
+      ? target.basename()
+      : link.basename()
     const match = base.match(/^tea_([^\/]+)$/)
     args = ["-X", match?.[1] ?? base, ...args]
   })()

--- a/tests/integration/tea-XX.test.ts
+++ b/tests/integration/tea-XX.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "deno/testing/asserts.ts"
+import { assertEquals, assertMatch } from "deno/testing/asserts.ts"
 import { sandbox } from '../utils.ts'
 
 //TODO verify that python version is actually what we request
@@ -21,5 +21,12 @@ Deno.test("tea -SX python3.11", async () => {
   await sandbox(async ({ run }) => {
     const out = await run({args: ["-SX", "python3.11", "-c", "print(3)"], net: true }).stdout()
     assertEquals(out, "3\n")
+  })
+})
+
+Deno.test("tea -SX node^16", async () => {
+  await sandbox(async ({ run }) => {
+    const out = await run({args: ["-SX", "node^16", "--version"], net: true }).stdout()
+    assertMatch(out, /^v16\./)
   })
 })


### PR DESCRIPTION
interpret that as `tea -X foo [args…]`, yet another way using `tea` can be
completely transparent to your everyday workflows.

Even better, you can include semver ranges in your link name, so `ln -s tea node^16`
will let you run `node^16` via the symlink of the same name. For even, even more
goodness, we will follow a symlink one deep to see if a base link goes to a versioned
link. Example:

```sh
$ ln -s tea node^16
$ ln -s node node^16
$ node --version
v16.19.0
```

> ### Coming Soon
>
> ```yaml